### PR TITLE
Fix Mutexes in pnb.pbi

### DIFF
--- a/src/functions/pnb_variables.pbi
+++ b/src/functions/pnb_variables.pbi
@@ -1,10 +1,19 @@
 ﻿Procedure PNB_Variables(List nList.nList())
   ClearList(nList())
+  
+  CompilerIf #PB_Compiler_Thread = 1
+    LockMutex(MutexVarMap)
+  CompilerEndIf
+  
   ForEach Memory()
     AddElement(nList())
     nList()\s = MapKey(Memory())
     nList()\Flags | #PNB_TYPE_NAME
   Next
+  
+  CompilerIf #PB_Compiler_Thread = 1
+    UnlockMutex(MutexVarMap)
+  CompilerEndIf
   
 EndProcedure
 

--- a/src/pnb.pbi
+++ b/src/pnb.pbi
@@ -2625,6 +2625,9 @@ Module PNB
           Case "Unfunction"
             ForEach nList()
               If nList()\Flags & #PNB_TYPE_NAME
+                CompilerIf #PB_Compiler_Thread = 1
+                  LockMutex(MutexFunMap)
+                CompilerEndIf
                 If FindMapElement(Lexicon(), nList()\s)
                   DeleteMapElement(Lexicon())
                   If FindMapElement(Param(), nList()\s)
@@ -2634,6 +2637,9 @@ Module PNB
                     EndIf
                   EndIf
                 EndIf
+                CompilerIf #PB_Compiler_Thread = 1
+                  UnlockMutex(MutexFunMap)
+                CompilerEndIf
               EndIf
               DeleteElement(nList())
             Next
@@ -3153,7 +3159,7 @@ Module PNB
             ;-#Function evaluation
           Default
             CompilerIf #PB_Compiler_Thread = 1
-              LockMutex(MutexVarMap)
+              LockMutex(MutexFunMap)
             CompilerEndIf
             If FindMapElement(Lexicon(), CAR)
               DeleteElement(nList())
@@ -3183,14 +3189,14 @@ Module PNB
                       EndIf
                     Next
                     CompilerIf #PB_Compiler_Thread = 1
-                      UnlockMutex(MutexVarMap)
+                      UnlockMutex(MutexFunMap)
                     CompilerEndIf
                     ClearList(nList())
                     nListEval(cList1()\nList())
                     MergeLists(cList1()\nList(), nList(), #PB_List_After)
                   Else
                     CompilerIf #PB_Compiler_Thread = 1
-                      UnlockMutex(MutexVarMap)
+                      UnlockMutex(MutexFunMap)
                     CompilerEndIf
                     ClearList(nList())
                   EndIf
@@ -3204,14 +3210,14 @@ Module PNB
                       DeleteElement(nList())
                     Next
                     CompilerIf #PB_Compiler_Thread = 1
-                      UnlockMutex(MutexVarMap)
+                      UnlockMutex(MutexFunMap)
                     CompilerEndIf
                     ClearList(nList())
                     nListEval(cList1()\nList())
                     MergeLists(cList1()\nList(), nList(), #PB_List_After)
                   Else
                     CompilerIf #PB_Compiler_Thread = 1
-                      UnlockMutex(MutexVarMap)
+                      UnlockMutex(MutexFunMap)
                     CompilerEndIf
                     ClearList(nList())
                   EndIf
@@ -3220,7 +3226,7 @@ Module PNB
                 AddElement(cList1())
                 cList1() = Lexicon()  
                 CompilerIf #PB_Compiler_Thread = 1
-                  UnlockMutex(MutexVarMap)
+                  UnlockMutex(MutexFunMap)
                 CompilerEndIf
                 ClearList(nList())
                 nListEval(cList1()\nList())
@@ -3228,7 +3234,7 @@ Module PNB
               EndIf
             Else
               CompilerIf #PB_Compiler_Thread = 1
-                UnlockMutex(MutexVarMap)
+                UnlockMutex(MutexFunMap)
               CompilerEndIf
             EndIf
         EndSelect


### PR DESCRIPTION
Fixed missing and mismatched mutexes
-For Unfunction, added mutex.
-For function evaluation, selected correct mutex.